### PR TITLE
Generic Field Mapping and Python3.11 Fixes

### DIFF
--- a/sigma/pipelines/microsoft365defender/microsoft365defender.py
+++ b/sigma/pipelines/microsoft365defender/microsoft365defender.py
@@ -10,7 +10,7 @@ from sigma.processing.transformations import FieldMappingTransformation, \
     RuleFailureTransformation, ReplaceStringTransformation, SetStateTransformation, DetectionItemTransformation, \
     ValueTransformation, DetectionItemFailureTransformation
 from sigma.processing.conditions import IncludeFieldCondition, \
-    RuleProcessingItemAppliedCondition, ExcludeFieldCondition
+    RuleProcessingItemAppliedCondition, ExcludeFieldCondition, DetectionItemProcessingItemAppliedCondition
 from sigma.conditions import ConditionOR
 from sigma.types import SigmaString, SigmaType
 from sigma.processing.pipeline import ProcessingItem, ProcessingPipeline
@@ -399,12 +399,12 @@ generic_field_mappings_proc_item = [ProcessingItem(
     transformation=FieldMappingTransformation(
         generic_field_mappings
     ),
-    rule_conditions=[
-        RuleProcessingItemAppliedCondition(f"microsoft_365_defender_fieldmappings_{table_name}")
+    detection_item_conditions=[
+        DetectionItemProcessingItemAppliedCondition(f"microsoft_365_defender_fieldmappings_{table_name}")
         for table_name in table_to_category_mappings.keys()
     ],
-    rule_condition_linking=any,
-    rule_condition_negation=True,
+    detection_item_condition_linking=any,
+    detection_item_condition_negation=True,
 )
 ]
 ## Field Value Replacements ProcessingItems
@@ -479,7 +479,8 @@ field_error_proc_items = [
             # Combine field mappings for table and generic field mappings dicts, get the unique keys, add the Hashes field, sort it
             f"{', '.join(sorted(set({**query_table_field_mappings[table_name], **generic_field_mappings}.keys()).union({'Hashes'})))}"
         ),
-        field_name_conditions=[ExcludeFieldCondition(fields=table_fields)],
+        field_name_conditions=[
+            ExcludeFieldCondition(fields=table_fields + list(generic_field_mappings.keys()) + ['Hashes'])],
         rule_conditions=[
             category_to_conditions_mappings[rule_category]
             for rule_category in table_to_category_mappings[table_name]

--- a/sigma/pipelines/microsoft365defender/microsoft365defender.py
+++ b/sigma/pipelines/microsoft365defender/microsoft365defender.py
@@ -416,25 +416,25 @@ replacement_proc_items = [
     # Do this one first, or else the HKLM only one will replace HKLM and mess up the regex
     ProcessingItem(
         identifier="microsoft_365_defender_registry_key_replace_currentcontrolset",
-        transformation=ReplaceStringTransformation(regex=r"((?i)^HKLM\\SYSTEM\\CurrentControlSet)",
+        transformation=ReplaceStringTransformation(regex=r"(?i)(^HKLM\\SYSTEM\\CurrentControlSet)",
                                                    replacement=r"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet001"),
         field_name_conditions=[IncludeFieldCondition(['RegistryKey', 'PreviousRegistryKey'])]
     ),
     ProcessingItem(
         identifier="microsoft_365_defender_registry_key_replace_hklm",
-        transformation=ReplaceStringTransformation(regex=r"((?i)^HKLM)",
+        transformation=ReplaceStringTransformation(regex=r"(?i)(^HKLM)",
                                                    replacement=r"HKEY_LOCAL_MACHINE"),
         field_name_conditions=[IncludeFieldCondition(['RegistryKey', 'PreviousRegistryKey'])]
     ),
     ProcessingItem(
         identifier="microsoft_365_defender_registry_key_replace_hku",
-        transformation=ReplaceStringTransformation(regex=r"((?i)^HKU)",
+        transformation=ReplaceStringTransformation(regex=r"(?i)(^HKU)",
                                                    replacement=r"HKEY_USERS"),
         field_name_conditions=[IncludeFieldCondition(['RegistryKey', 'PreviousRegistryKey'])]
     ),
     ProcessingItem(
         identifier="microsoft_365_defender_registry_key_replace_hkcr",
-        transformation=ReplaceStringTransformation(regex=r"((?i)^HKCR)",
+        transformation=ReplaceStringTransformation(regex=r"(?i)(^HKCR)",
                                                    replacement=r"HKEY_LOCAL_MACHINE\\CLASSES"),
         field_name_conditions=[IncludeFieldCondition(['RegistryKey', 'PreviousRegistryKey'])]
     ),

--- a/tests/test_backend_microsoft365defender.py
+++ b/tests/test_backend_microsoft365defender.py
@@ -2,12 +2,13 @@ import pytest
 from sigma.collection import SigmaCollection
 from sigma.backends.microsoft365defender import Microsoft365DefenderBackend
 
+
 @pytest.fixture
 def microsoft365defender_backend():
     return Microsoft365DefenderBackend()
 
-# TODO: implement tests for some basic queries and their expected results.
-def test_microsoft365defender_and_expression(microsoft365defender_backend : Microsoft365DefenderBackend):
+
+def test_microsoft365defender_and_expression(microsoft365defender_backend: Microsoft365DefenderBackend):
     assert microsoft365defender_backend.convert(
         SigmaCollection.from_yaml("""
             title: Test
@@ -23,7 +24,8 @@ def test_microsoft365defender_and_expression(microsoft365defender_backend : Micr
         """)
     ) == ['DeviceProcessEvents\n| where ProcessCommandLine =~ "valueA" and AccountName =~ "valueB"']
 
-def test_microsoft365defender_or_expression(microsoft365defender_backend : Microsoft365DefenderBackend):
+
+def test_microsoft365defender_or_expression(microsoft365defender_backend: Microsoft365DefenderBackend):
     assert microsoft365defender_backend.convert(
         SigmaCollection.from_yaml("""
             title: Test
@@ -40,7 +42,8 @@ def test_microsoft365defender_or_expression(microsoft365defender_backend : Micro
         """)
     ) == ['DeviceProcessEvents\n| where ProcessCommandLine =~ "valueA" or AccountName =~ "valueB"']
 
-def test_microsoft365defender_and_or_expression(microsoft365defender_backend : Microsoft365DefenderBackend):
+
+def test_microsoft365defender_and_or_expression(microsoft365defender_backend: Microsoft365DefenderBackend):
     assert microsoft365defender_backend.convert(
         SigmaCollection.from_yaml("""
             title: Test
@@ -62,7 +65,7 @@ def test_microsoft365defender_and_or_expression(microsoft365defender_backend : M
           'ProcessId has_any ("valueB1", "valueB2")']
 
 
-def test_microsoft365defender_or_and_expression(microsoft365defender_backend : Microsoft365DefenderBackend):
+def test_microsoft365defender_or_and_expression(microsoft365defender_backend: Microsoft365DefenderBackend):
     assert microsoft365defender_backend.convert(
         SigmaCollection.from_yaml("""
             title: Test
@@ -82,7 +85,8 @@ def test_microsoft365defender_or_and_expression(microsoft365defender_backend : M
     ) == ['DeviceProcessEvents\n| where (ProcessCommandLine =~ "valueA1" and ProcessId =~ "valueB1") or '
           '(ProcessCommandLine =~ "valueA2" and ProcessId =~ "valueB2")']
 
-def test_microsoft365defender_in_expression(microsoft365defender_backend : Microsoft365DefenderBackend):
+
+def test_microsoft365defender_in_expression(microsoft365defender_backend: Microsoft365DefenderBackend):
     assert microsoft365defender_backend.convert(
         SigmaCollection.from_yaml("""
             title: Test
@@ -102,7 +106,7 @@ def test_microsoft365defender_in_expression(microsoft365defender_backend : Micro
           'ProcessCommandLine startswith "valueC"']
 
 
-def test_microsoft365defender_regex_query(microsoft365defender_backend : Microsoft365DefenderBackend):
+def test_microsoft365defender_regex_query(microsoft365defender_backend: Microsoft365DefenderBackend):
     assert microsoft365defender_backend.convert(
         SigmaCollection.from_yaml("""
             title: Test
@@ -118,7 +122,8 @@ def test_microsoft365defender_regex_query(microsoft365defender_backend : Microso
         """)
     ) == ['DeviceProcessEvents\n| where ProcessCommandLine matches regex "foo.*bar" and ProcessId =~ "foo"']
 
-def test_microsoft365defender_cidr_query(microsoft365defender_backend : Microsoft365DefenderBackend):
+
+def test_microsoft365defender_cidr_query(microsoft365defender_backend: Microsoft365DefenderBackend):
     assert microsoft365defender_backend.convert(
         SigmaCollection.from_yaml("""
             title: Test
@@ -132,5 +137,3 @@ def test_microsoft365defender_cidr_query(microsoft365defender_backend : Microsof
                 condition: sel
         """)
     ) == ['DeviceNetworkEvents\n| where ipv4_is_in_range(LocalIP, "192.168.0.0/16")']
-
-

--- a/tests/test_pipelines_microsoft365defender.py
+++ b/tests/test_pipelines_microsoft365defender.py
@@ -499,6 +499,25 @@ def test_microsoft_365_defender_pipeline_registry_actiontype_replacements():
                'ActionType =~ "RegistryValueSet" or '
                'ActionType has_any ("RegistryValueSet", "RegistryKeyCreated")']
 
+    def test_microsoft_365_defender_pipeline_generic_field():
+        """Tests"""
+        assert Microsoft365DefenderBackend(processing_pipeline=microsoft_365_defender_pipeline()).convert(
+            SigmaCollection.from_yaml("""
+                    title: Test
+                    status: test
+                    logsource:
+                        category: file_event
+                        product: windows
+                    detection:
+                        sel1:
+                            CommandLine: whoami
+                            ProcessId: 1  
+                        condition: any of sel*
+                """)
+        ) == [
+                   'DeviceFileEvents\n| '
+                   'where InitiatingProcessCommandLine =~ "whoami" and InitiatingProcessId == 1']
+
 
 def test_microsoft_365_defender_pipeline_unsupported_rule_type():
     with pytest.raises(SigmaTransformationError,


### PR DESCRIPTION
- Fixed an issue where a condition was being applied to a whole rule rather than individual detection items, causing issues when using generic field mappings (fixes #2 )
- Fixed Python v3.11 regex compatibility, moved the case-insensitive global flag to the beginning of registry pipeline regexes (fixes #3)
- General whitespace/readability edits