### PR TITLE
Fix minor issues

### DIFF
--- a/sigma/backends/microsoft365defender/microsoft365defender.py
+++ b/sigma/backends/microsoft365defender/microsoft365defender.py
@@ -18,6 +18,7 @@ class Microsoft365DefenderBackend(TextQueryBackend):
 
     # The backend generates grouping if required
     name: ClassVar[str] = "Microsoft 365 Defender backend"
+    identifier: ClassVar[str] = "microsoft365defender"
     formats: Dict[str, str] = {
         "default": "KQL for Microsoft 365 Defender Advanced Hunting queries",
     }

--- a/sigma/pipelines/microsoft365defender/microsoft365defender.py
+++ b/sigma/pipelines/microsoft365defender/microsoft365defender.py
@@ -597,4 +597,5 @@ def microsoft_365_defender_pipeline(transform_parent_image: Optional[bool] = Tru
         name="Generic Log Sources to Windows 365 Defender Transformation",
         priority=10,
         items=pipeline_items,
+        allowed_backends=frozenset(["microsoft365defender"]),
     )


### PR DESCRIPTION
The purpose of this PR is to restrict the pipeline to the existing backend, specifically `microsoft365defender`, rather than supporting all backends available in Sigma. To achieve this, the backend identifier is set to `microsoft365defender`, and the `allowed_backends` property is configured accordingly.